### PR TITLE
Prevent tab pane from activating twice

### DIFF
--- a/js/responsive-tabs.js
+++ b/js/responsive-tabs.js
@@ -152,26 +152,32 @@ var fakewaffle = ( function ( $, fakewaffle ) {
 
 		// Toggle the panels when the associated tab is toggled
 		tabs.on( 'shown.bs.tab', function ( e ) {
-			var $current  = $( e.currentTarget.hash.replace( /#/, '#collapse-' ) );
-			$current.collapse( 'show' );
-
-			if ( e.relatedTarget ) {
-				var $previous = $( e.relatedTarget.hash.replace( /#/, '#collapse-' ) );
-				$previous.collapse( 'hide' );
+			
+			if (fakewaffle.currentPosition === 'tabs') {
+				var $current  = $( e.currentTarget.hash.replace( /#/, '#collapse-' ) );
+				$current.collapse( 'show' );
+	
+				if ( e.relatedTarget ) {
+					var $previous = $( e.relatedTarget.hash.replace( /#/, '#collapse-' ) );
+					$previous.collapse( 'hide' );
+				}
 			}
+			
 		} );
 
 		// Toggle the tab when the associated panel is toggled
 		collapse.on( 'shown.bs.collapse', function ( e ) {
-
-			// Activate current tabs
-			var current = $( e.target ).context.id.replace( /collapse-/g, '#' );
-			$( 'a[href="' + current + '"]' ).tab( 'show' );
-
-			// Update the content with active
-			var panelGroup = $( e.currentTarget ).closest( '.panel-group.responsive' );
-			$( panelGroup ).find( '.panel-body' ).removeClass( 'active' );
-			$( e.currentTarget ).find( '.panel-body' ).addClass( 'active' );
+			
+			if (fakewaffle.currentPosition === 'panel') {
+				// Activate current tabs
+				var current = $( e.target ).context.id.replace( /collapse-/g, '#' );
+				$( 'a[href="' + current + '"]' ).tab( 'show' );
+	
+				// Update the content with active
+				var panelGroup = $( e.currentTarget ).closest( '.panel-group.responsive' );
+				$( panelGroup ).find( '.panel-body' ).removeClass( 'active' );
+				$( e.currentTarget ).find( '.panel-body' ).addClass( 'active' );
+			}
 
 		} );
 	};


### PR DESCRIPTION
Due to the bindTabToCollapse function, activating a tab activates a panel, and activating a panel activates a tab. This causes double activation which can cause an animation glitch.

Open the demo and click "Key Features" and then "Source" in quick succession. After source loads, key features loads a second time and then source loads a second time. Alternatively, add the "fade" class to the tab panes and watch the content fade in then out then in again.
